### PR TITLE
Include homebridge ^2.0.0-beta.27 to "engines"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": ">=14.18.1",
-    "homebridge": ">=1.3.5"
+    "homebridge": ">=1.3.5 || ^2.0.0-beta.27"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Tested the plugin with homebridge v2.0, all seems to work well