### PR TITLE
Add Homebridge 2 compatibility and cached accessory fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ This plugin was developed to be installed and configured with
 It can be found by searching for `air-Q` in the `Plugins` section.
 It supports Homebridge `^1.1.0` and `^2.0.0`.
 
+## Compatibility
+
+This plugin supports Homebridge 1 and Homebridge 2.
+No configuration changes are required when using Homebridge 2.
+
 ## Working Principle
 
 1. The plugin performs an mDNS scan to find all air-Qs in the connected network.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ on the [Homebridge Platform Plugin Template](https://github.com/homebridge/homeb
 This plugin was developed to be installed and configured with
 [homebridge-config-ui-x](https://www.npmjs.com/package/homebridge-config-ui-x).
 It can be found by searching for `air-Q` in the `Plugins` section.
+It supports Homebridge `^1.1.0` and `^2.0.0`.
 
 ## Working Principle
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": ">=14.18.1",
-    "homebridge": ">=1.3.5 || ^2.0.0-beta.27"
+    "homebridge": "^1.1.0 || ^2.0.0"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -38,7 +38,7 @@ export class AirQPlatform implements DynamicPlatformPlugin {
   }
 
   discoverDevices() {
-    const browser = (Bonjour() as any).find({ type: 'http' });
+    const browser = (new Bonjour() as any).find({ type: 'http' });
 
     browser.on('up', this.foundAirQ.bind(this));
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -132,6 +132,13 @@ export class AirQPlatform implements DynamicPlatformPlugin {
                 if (existingAccessory) {
                   this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
                   existingAccessory.context.device = device;
+
+                  for (const service of existingAccessory.services) {
+                    if (service.UUID !== this.Service.AccessoryInformation.UUID) {
+                      existingAccessory.removeService(service);
+                    }
+                  }
+
                   new AirQPlatformAccessory(this, existingAccessory);
                   return;
                 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -133,7 +133,7 @@ export class AirQPlatform implements DynamicPlatformPlugin {
                   this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
                   existingAccessory.context.device = device;
 
-                  for (const service of existingAccessory.services) {
+                  for (const service of [...existingAccessory.services]) {
                     if (service.UUID !== this.Service.AccessoryInformation.UUID) {
                       existingAccessory.removeService(service);
                     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -130,16 +130,10 @@ export class AirQPlatform implements DynamicPlatformPlugin {
                 const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
 
                 if (existingAccessory) {
-                  // the accessory already exists
-                  // as the bug message "Error: Cannot add a Service with the same UUID '...'
-                  // and subtype '...' as another Service in this Accessory."
-                  // could not be fixed yet, the device is removed from cache and then added again
-                  // as a new device
-
-                  this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
-                  this.accessories.splice(this.accessories.indexOf(existingAccessory), 1);
-                  this.log.debug('Removed existing accessory from cache:', existingAccessory.displayName);
-
+                  this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+                  existingAccessory.context.device = device;
+                  new AirQPlatformAccessory(this, existingAccessory);
+                  return;
                 }
 
                 // the accessory does not yet exist, so we need to create it

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -10,6 +10,7 @@ export class AirQPlatform implements DynamicPlatformPlugin {
 
   // this is used to track restored cached accessories
   public readonly accessories: PlatformAccessory[] = [];
+  private readonly pendingAccessories = new Set<string>();
 
   constructor(
     public readonly log: Logger,
@@ -118,6 +119,12 @@ export class AirQPlatform implements DynamicPlatformPlugin {
                 const uuid = this.api.hap.uuid.generate(mdnsService.txt.id);
                 this.log.info('\tUUID:', uuid);
 
+                if (this.pendingAccessories.has(uuid)) {
+                  this.log.debug('Skipping accessory update while setup is already in progress:', name);
+                  return;
+                }
+                this.pendingAccessories.add(uuid);
+
                 // see if an accessory with the same uuid has already been registered and restored from
                 // the cached devices we stored in the `configureAccessory` method above
                 const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
@@ -130,6 +137,7 @@ export class AirQPlatform implements DynamicPlatformPlugin {
                   // as a new device
 
                   this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
+                  this.accessories.splice(this.accessories.indexOf(existingAccessory), 1);
                   this.log.debug('Removed existing accessory from cache:', existingAccessory.displayName);
 
                 }
@@ -150,7 +158,12 @@ export class AirQPlatform implements DynamicPlatformPlugin {
 
                 // link the accessory to your platform
                 this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+                this.accessories.push(accessory);
               }
+            })
+            .finally(() => {
+              const uuid = this.api.hap.uuid.generate(mdnsService.txt.id);
+              this.pendingAccessories.delete(uuid);
             })
             .catch(error => {
               this.log.error(error);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -67,6 +67,13 @@ export class AirQPlatform implements DynamicPlatformPlugin {
       // choose the corresponding device from homebridge plugin configuration
       for (const i in this.config.airqList) {
         if (this.config.airqList[i].serialNumber === shortId) {
+          const uuid = this.api.hap.uuid.generate(mdnsService.txt.id);
+
+          if (this.pendingAccessories.has(uuid)) {
+            this.log.debug('Skipping accessory update while setup is already in progress:', name);
+            return;
+          }
+          this.pendingAccessories.add(uuid);
 
           // set password as defined in user configuration
           const password = this.config.airqList[i].password;
@@ -116,14 +123,7 @@ export class AirQPlatform implements DynamicPlatformPlugin {
                 // generate a unique id for the accessory this should be generated from
                 // something globally unique, but constant, for example, the device serial
                 // number or MAC address
-                const uuid = this.api.hap.uuid.generate(mdnsService.txt.id);
                 this.log.info('\tUUID:', uuid);
-
-                if (this.pendingAccessories.has(uuid)) {
-                  this.log.debug('Skipping accessory update while setup is already in progress:', name);
-                  return;
-                }
-                this.pendingAccessories.add(uuid);
 
                 // see if an accessory with the same uuid has already been registered and restored from
                 // the cached devices we stored in the `configureAccessory` method above
@@ -162,7 +162,6 @@ export class AirQPlatform implements DynamicPlatformPlugin {
               }
             })
             .finally(() => {
-              const uuid = this.api.hap.uuid.generate(mdnsService.txt.id);
               this.pendingAccessories.delete(uuid);
             })
             .catch(error => {


### PR DESCRIPTION
## Summary

- add Homebridge 2 compatibility in ngines.homebridge
- update README with Homebridge 2 compatibility information
- build the plugin automatically during git installs via prepare
- instantiate onjour-hap in a TypeScript-compatible way for git-install builds
- prevent duplicate accessory registration during discovery
- reuse cached accessories and rebuild their services cleanly on restore

## Notes

- Homebridge 1 still starts correctly after the cache-restore adjustments
- the Homebridge 2 work specifically avoids re-bridging accessories that Homebridge already restored from cache
